### PR TITLE
Support Cypress 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - chore(#382): Use Cypress v9 in E2E tests
 - chore(#382): Support any Cypress version greater than 2.1.0
+- chore(deps): Update devDependencies
 
 ## [1.6.0] - 2021-11-01
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
+## [1.6.1] - 2021-11-11
+### Changed
+- chore(#382): Use Cypress v9 in E2E tests
+- chore(#382): Support any Cypress version greater than 2.1.0
+
 ## [1.6.0] - 2021-11-01
 ### Changed
 - chore(deps): Update devDependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-localstorage-commands",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-localstorage-commands",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Extends Cypress' cy commands with localStorage methods. Allows preserving localStorage between tests",
   "keywords": [
     "cypress",
@@ -43,7 +43,7 @@
     "prepare": "is-ci || husky install"
   },
   "peerDependencies": {
-    "cypress": "^2.1.0 || 3.x || 4.x || 5.x || 6.x || 7.x || 8.x"
+    "cypress": ">=2.1.0"
   },
   "devDependencies": {
     "@stryker-mutator/core": "5.4.1",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_cypress-localstorage-commands
-sonar.projectVersion=1.6.0
+sonar.projectVersion=1.6.1
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/test-e2e/react-app/package-lock.json
+++ b/test-e2e/react-app/package-lock.json
@@ -1254,9 +1254,9 @@
       "dev": true
     },
     "@cypress/request": {
-      "version": "2.88.6",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.6.tgz",
-      "integrity": "sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==",
+      "version": "2.88.7",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.7.tgz",
+      "integrity": "sha512-FTULIP2rnDJvZDT9t6B4nSfYR40ue19tVmv3wUcY05R9/FPCoMl1nAPJkzWzBCo7ltVn5ThQTbxiMoGBN7k0ig==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -4959,6 +4959,12 @@
         }
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5720,12 +5726,12 @@
       "dev": true
     },
     "cypress": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.7.0.tgz",
-      "integrity": "sha512-b1bMC3VQydC6sXzBMFnSqcvwc9dTZMgcaOzT0vpSD+Gq1yFc+72JDWi55sfUK5eIeNLAtWOGy1NNb6UlhMvB+Q==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.0.0.tgz",
+      "integrity": "sha512-/93SWBZTw7BjFZ+I9S8SqkFYZx7VhedDjTtRBmXO0VzTeDbmxgK/snMJm/VFjrqk/caWbI+XY4Qr80myDMQvYg==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^2.88.6",
+        "@cypress/request": "^2.88.7",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
         "@types/sinonjs__fake-timers": "^6.0.2",
@@ -5760,7 +5766,6 @@
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
-        "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
@@ -5770,9 +5775,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.32",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-          "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
+          "version": "14.17.33",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
+          "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==",
           "dev": true
         },
         "ansi-styles": {
@@ -11868,16 +11873,17 @@
       "dev": true
     },
     "listr2": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.13.1.tgz",
-      "integrity": "sha512-pk4YBDA2cxtpM8iLHbz6oEsfZieJKHf6Pt19NlKaHZZVpqHyVs/Wqr7RfBBCeAFCJchGO7WQHVkUPZTvJMHk8w==",
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.13.3.tgz",
+      "integrity": "sha512-VqAgN+XVfyaEjSaFewGPcDs5/3hBbWVaX1VgWv2f52MF7US45JuARlArULctiB44IIcEk3JF7GtoFCLqEdeuPA==",
       "dev": true,
       "requires": {
         "cli-truncate": "^2.1.0",
+        "clone": "^2.1.2",
         "colorette": "^2.0.16",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
-        "rxjs": "^6.6.7",
+        "rxjs": "^7.4.0",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
@@ -14882,12 +14888,6 @@
         "performance-now": "^2.1.0"
       }
     },
-    "ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
-      "dev": true
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -15937,12 +15937,20 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "~2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {

--- a/test-e2e/react-app/package.json
+++ b/test-e2e/react-app/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@cypress/webpack-preprocessor": "5.9.1",
     "babel-plugin-module-resolver": "4.1.0",
-    "cypress": "8.7.0",
+    "cypress": "9.0.0",
     "react-scripts": "4.0.3",
     "serve": "12.0.1",
     "start-server-and-test": "1.14.0"

--- a/test-e2e/typescript/package-lock.json
+++ b/test-e2e/typescript/package-lock.json
@@ -83,9 +83,9 @@
       }
     },
     "@cypress/request": {
-      "version": "2.88.6",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.6.tgz",
-      "integrity": "sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==",
+      "version": "2.88.7",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.7.tgz",
+      "integrity": "sha512-FTULIP2rnDJvZDT9t6B4nSfYR40ue19tVmv3wUcY05R9/FPCoMl1nAPJkzWzBCo7ltVn5ThQTbxiMoGBN7k0ig==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -241,9 +241,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
+      "version": "14.17.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.33.tgz",
+      "integrity": "sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==",
       "dev": true
     },
     "@types/sinonjs__fake-timers": {
@@ -437,9 +437,9 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -635,6 +635,12 @@
         "string-width": "^4.2.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -708,12 +714,12 @@
       }
     },
     "cypress": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.7.0.tgz",
-      "integrity": "sha512-b1bMC3VQydC6sXzBMFnSqcvwc9dTZMgcaOzT0vpSD+Gq1yFc+72JDWi55sfUK5eIeNLAtWOGy1NNb6UlhMvB+Q==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.0.0.tgz",
+      "integrity": "sha512-/93SWBZTw7BjFZ+I9S8SqkFYZx7VhedDjTtRBmXO0VzTeDbmxgK/snMJm/VFjrqk/caWbI+XY4Qr80myDMQvYg==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^2.88.6",
+        "@cypress/request": "^2.88.7",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
         "@types/sinonjs__fake-timers": "^6.0.2",
@@ -748,7 +754,6 @@
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
-        "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
@@ -1648,16 +1653,17 @@
       }
     },
     "listr2": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.13.1.tgz",
-      "integrity": "sha512-pk4YBDA2cxtpM8iLHbz6oEsfZieJKHf6Pt19NlKaHZZVpqHyVs/Wqr7RfBBCeAFCJchGO7WQHVkUPZTvJMHk8w==",
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.13.3.tgz",
+      "integrity": "sha512-VqAgN+XVfyaEjSaFewGPcDs5/3hBbWVaX1VgWv2f52MF7US45JuARlArULctiB44IIcEk3JF7GtoFCLqEdeuPA==",
       "dev": true,
       "requires": {
         "cli-truncate": "^2.1.0",
+        "clone": "^2.1.2",
         "colorette": "^2.0.16",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
-        "rxjs": "^6.6.7",
+        "rxjs": "^7.4.0",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       }
@@ -1776,18 +1782,18 @@
       }
     },
     "mime-db": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.33",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
-      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "dev": true,
       "requires": {
-        "mime-db": "1.50.0"
+        "mime-db": "1.51.0"
       }
     },
     "mimic-fn": {
@@ -2027,12 +2033,6 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
-      "dev": true
-    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -2095,12 +2095,20 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "~2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {

--- a/test-e2e/typescript/package.json
+++ b/test-e2e/typescript/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "5.2.0",
     "@typescript-eslint/parser": "5.2.0",
-    "cypress": "8.7.0",
+    "cypress": "9.0.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "3.4.1",


### PR DESCRIPTION
### Changed
- chore(#382): Use Cypress v9 in E2E tests
- chore(#382): Support any Cypress version greater than 2.1.0
- chore(deps): Update devDependencies

closes #382 