### PR TITLE
Do not use set-output in pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
       - master
       - release
   pull_request:
+concurrency:  
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: build
 on:
   push:
-    branches:
-      - master
-      - release
   pull_request:
 concurrency:  
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: build
 on:
   push:
+    branches:
+      - master
+      - release
   pull_request:
 jobs:
   test:
@@ -15,8 +18,6 @@ jobs:
         shell: bash
         run: echo "branch=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
         id: extract-branch
-      - name: Trace branch name
-        run: echo ${{ steps.extract-branch.outputs.branch }}
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - release
-      - chore/do-not-use-set-output
   pull_request:
 concurrency:  
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 on:
   push:
+    branches:
+      - master
+      - release
+      - chore/do-not-use-set-output
   pull_request:
 concurrency:  
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: build
 on:
   push:
-    branches:
-      - master
-      - release
   pull_request:
 jobs:
   test:
@@ -16,8 +13,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
+        run: echo "branch=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
         id: extract-branch
+      - name: Trace branch name
+        run: echo ${{ steps.extract-branch.outputs.branch }}
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+## [unreleased]
+
+### Added
+* chore: Handle jobs concurrency in build workflow
+
+### Changed
+* chore: Remove usage of "set-output" in build workflow
+
 ## [2.2.5] - 2023-11-15
 
 ### Changed


### PR DESCRIPTION
### Added
* chore: Handle jobs concurrency in build workflow

### Changed
* chore: Remove usage of "set-output" in build workflow